### PR TITLE
Add zsh prescript to gradle for autoloading compinit

### DIFF
--- a/plugins/gradle-completion_gradle/index.ts
+++ b/plugins/gradle-completion_gradle/index.ts
@@ -22,6 +22,7 @@ const plugin: Fig.Plugin = {
       sourceFiles: ["gradle-completion.bash"],
     },
     zsh: {
+      preScript: "autoload -Uz compinit; compinit",
       sourceFiles: ["gradle-completion.plugin.zsh"],
     },
   },


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

You get `command not found: compdef` when downloading the plugin.

**What is the new behavior (if this is a feature change)?**

It works now.

**Additional info:**

 Solved by adding this to the index.ts:
```
autoload -Uz compinit
compinit
```