### PR TITLE
[fix] Edit displayName

### DIFF
--- a/plugins/alias-tips_djui/index.ts
+++ b/plugins/alias-tips_djui/index.ts
@@ -39,7 +39,7 @@ const plugin: Fig.Plugin = {
       name: "ZSH_PLUGINS_ALIAS_TIPS_EXCLUDES",
     },
     {
-      displayName: "Disable Command Expansion",
+      displayName: "Command Expansion",
       type: "environmentVariable",
       description:
         "If you have several alias, e.g. for different git commands the command get expanded before looking for an alias.",


### PR DESCRIPTION
Change displayName to "Command Expansion" excluding "Disable" because it wasn't an exactly name of working.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Name fix: displayName

**What is the current behavior? (You can also link to an open issue here)**
It shows "Disable Command Expansion".

**What is the new behavior (if this is a feature change)?**
It shows "Command Expansion" excluding "Disable".

**Additional info:**
If you have some time, please help for this issue https://github.com/withfig/plugins/issues/34#issue-1288336385.