### PR TITLE
feat: added light version for vercel zsh theme

### DIFF
--- a/plugins/zsh-theme_vercel_light/README.md
+++ b/plugins/zsh-theme_vercel_light/README.md
@@ -1,0 +1,7 @@
+# vercel.zsh-theme
+
+▲Vercel's `zsh` theme modified for light mode terminals
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/vercel/zsh-theme/master/screenshot.png?v=2">
+</p>

--- a/plugins/zsh-theme_vercel_light/index.ts
+++ b/plugins/zsh-theme_vercel_light/index.ts
@@ -1,0 +1,24 @@
+const plugin: Fig.Plugin = {
+  icon: "▲",
+  name: "zsh-theme_vercel_light",
+  displayName: "Vercel Zsh Light Theme",
+  type: "shell",
+  description: "Yet another zsh theme",
+  authors: [
+    {
+      name: "Daniel Munoz Gonzalez",
+      github: "ataricoder",
+    },
+  ],
+  github: "ataricoder/vercel-zsh-theme",
+  license: ["MIT"],
+  shells: ["zsh"],
+  categories: ["Prompt"],
+  keywords: ["zsh", "oh-my-zsh", "shell", "hyper", "vercel"],
+  installation: {
+    origin: "github",
+    sourceFiles: ["ataricoder.vercel-zsh-theme"],
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Feature: Added a light mode version for Vercel's zsh theme.

**What is the current behavior? (You can also link to an open issue here)**

For users with light mode terminals, the current Vercel zsh theme does not play well.

**What is the new behavior (if this is a feature change)?**

Changed prompts color from white to black to allow for visibility in light mode terminals

**Additional info:**

Instead of manually installing and configuring oh-my-zsh to edit Vercel's zsh theme, this would allow for easy plugin installation via the Fig plugin store. I think what Fig is doing is awesome, and reduces the headache of maintaining local dot files