### PR TITLE
correct spaceship 12 hr time env var name

### DIFF
--- a/plugins/spaceship-prompt/index.ts
+++ b/plugins/spaceship-prompt/index.ts
@@ -239,7 +239,7 @@ const plugin: Fig.Plugin = {
           displayName: "12 Hour Time",
           description: "Format time using 12-hour clock (am/pm)",
           type: "environmentVariable",
-          name: "SPACESHIP_TIME_12_HOUR",
+          name: "SPACESHIP_TIME_12HR",
           interface: "toggle",
           default: false,
           compile: booleanCompile,


### PR DESCRIPTION
incorrect var name was being used causing the 12 hour time toggle not to function at all